### PR TITLE
Remove gtk plugins

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,16 +57,6 @@ services_in_files = \
 services_DATA = \
 	$(services_in_files:.service.in=.service)
 
-webkitoptionsdir = $(sysconfdir)/signon-ui/webkit-options.d
-dist_webkitoptions_DATA = \
-	data/webkit-options/api.instagram.com.conf \
-	data/webkit-options/api.weibo.com.conf \
-	data/webkit-options/api.t.sohu.com.conf \
-	data/webkit-options/foursquare.com.conf \
-	data/webkit-options/identi.ca.conf \
-	data/webkit-options/login.live.com.conf \
-	data/webkit-options/www.linkedin.com.conf
-
 # Temporary until these bugs are fixed:
 # https://bugs.launchpad.net/bugs/1567908
 # https://bugs.launchpad.net/bugs/1640704

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,75 +2,7 @@ SUBDIRS = \
 	po
 
 DISTCHECK_CONFIGURE_FLAGS = \
-	--enable-libaccount-plugin \
 	--enable-tests
-
-if ENABLE_LIBACCOUNT_PLUGIN
-# Binary account plugins.
-plugin_LTLIBRARIES = \
-	libfacebook.la \
-	libflickr.la \
-	libgeneric-oauth.la \
-	libgoogle.la \
-	libtwitter.la
-
-VALAFLAGS = \
-	--vapidir $(top_srcdir)/src \
-	--pkg config \
-	--pkg AccountPlugin \
-	--pkg libaccounts-glib \
-	--pkg posix \
-	--pkg signon \
-	--pkg gtk+-3.0 \
-	--pkg gmodule-2.0
-
-plugin_cppflags = \
-	$(ACCOUNT_PLUGINS_CFLAGS) \
-	-include $(top_builddir)/config.h \
-	$(WARN_CFLAGS)
-
-plugin_libadd = \
-	$(ACCOUNT_PLUGINS_LIBS)
-
-plugin_ldflags = \
-	-export_dynamic \
-	-avoid-version \
-	-module \
-	-no-undefined \
-	-export-symbols-regex '^ap_module_get_object_type'
-
-libfacebook_la_CPPFLAGS = $(plugin_cppflags) $(RESTAPIS_CFLAGS)
-libfacebook_la_LIBADD = $(plugin_libadd) $(RESTAPIS_LIBS)
-libfacebook_la_LDFLAGS = $(plugin_ldflags)
-libfacebook_la_VALAFLAGS = --pkg libsoup-2.4 --pkg json-glib-1.0
-libfacebook_la_SOURCES = \
-	src/facebook.vala
-
-libflickr_la_CPPFLAGS = $(plugin_cppflags)
-libflickr_la_LIBADD = $(plugin_libadd)
-libflickr_la_LDFLAGS = $(plugin_ldflags)
-libflickr_la_SOURCES = \
-	src/flickr.vala
-
-libgoogle_la_CPPFLAGS = $(plugin_cppflags) $(RESTAPIS_CFLAGS)
-libgoogle_la_LIBADD = $(plugin_libadd) $(RESTAPIS_LIBS)
-libgoogle_la_LDFLAGS = $(plugin_ldflags)
-libgoogle_la_VALAFLAGS = --pkg libsoup-2.4 --pkg json-glib-1.0
-libgoogle_la_SOURCES = \
-	src/google.vala
-
-libtwitter_la_CPPFLAGS = $(plugin_cppflags)
-libtwitter_la_LIBADD = $(plugin_libadd)
-libtwitter_la_LDFLAGS = $(plugin_ldflags)
-libtwitter_la_SOURCES = \
-	src/twitter.vala
-
-libgeneric_oauth_la_CPPFLAGS = $(plugin_cppflags)
-libgeneric_oauth_la_LIBADD = $(plugin_libadd)
-libgeneric_oauth_la_LDFLAGS = $(plugin_ldflags)
-libgeneric_oauth_la_SOURCES = \
-	src/generic-oauth.vala
-endif # ENABLE_LIBACCOUNT_PLUGIN
 
 if ENABLE_QML_PLUGINS
 SUBDIRS += qml
@@ -149,8 +81,7 @@ dist_bin_SCRIPTS = \
 	tools/account-console
 
 dist_noinst_DATA = \
-	$(services_in_files) \
-	src/config.vapi
+	$(services_in_files)
 
 if HAVE_XMLLINT
 TESTS = \

--- a/configure.ac
+++ b/configure.ac
@@ -9,18 +9,9 @@ AC_INIT([account-plugins],
 AM_INIT_AUTOMAKE([1.10 -Wall -Wno-portability silent-rules subdir-objects])
 AM_CONFIG_HEADER(config.h)
 
-# Gobject Introspection
 AC_CONFIG_MACRO_DIR([m4])
-GOBJECT_INTROSPECTION_CHECK([1.30.0])
 
 # Check for programs
-AC_PROG_CC
-AM_PROG_CC_C_O
-OVERRIDE_PROG_VALAC([0.15.1], [valac-0.16 valac-0.14 valac])
-
-LT_PREREQ([2.2])
-LT_INIT([disable-static])
-
 IT_PROG_INTLTOOL([0.50.0])
 AC_SUBST([GETTEXT_PACKAGE], [$PACKAGE_TARNAME])
 
@@ -30,32 +21,8 @@ AS_IF([test "x$prefix" = "xNONE"],
       [real_prefix=$ac_default_prefix],
       [real_prefix=$prefix])
 
-# Binary account plugins.
-AC_ARG_ENABLE([libaccount-plugin],
-              [AS_HELP_STRING([--disable-libaccount-plugin],
-                              [build without support for libaccount-plugin (binary account plugins)])])
-
-AS_IF([test "x$enable_libaccount_plugin" != "xno"],
-      [PKG_CHECK_EXISTS([account-plugin], [have_libaccount_plugin=yes],
-                        [have_libaccount_plugin=no])],
-      [have_libaccount_plugin=no])
-
-AS_IF([test "x$have_libaccount_plugin" = "xyes"],
-      [
-        PKG_CHECK_MODULES([ACCOUNT_PLUGINS], [account-plugin >= 0.1.3])
-        PKG_CHECK_MODULES([RESTAPIS], [libsoup-2.4 json-glib-1.0])
-      ],
-      [AS_IF([test "x$enable_libaccount_plugin" = "xyes"],
-             [AC_MSG_ERROR([libaccount-plugin support enabled but required dependencies were not found])])])
-
-AM_CONDITIONAL([ENABLE_LIBACCOUNT_PLUGIN],
-               [test "x$have_libaccount_plugin" = "xyes"])
-
 # XML data files for libaccounts-glib.
 PKG_CHECK_EXISTS([libaccounts-glib])
-
-AC_SUBST([plugindir],
-         [`$PKG_CONFIG --variable provider_plugindir --define-variable=prefix=$real_prefix account-plugin`])
 
 # QML account plugins.
 AC_ARG_ENABLE([qml-plugins],

--- a/data/webkit-options/api.instagram.com.conf
+++ b/data/webkit-options/api.instagram.com.conf
@@ -1,2 +1,0 @@
-UsernameField = input[id="username"]
-PasswordField = input[id="password"]

--- a/data/webkit-options/api.t.sohu.com.conf
+++ b/data/webkit-options/api.t.sohu.com.conf
@@ -1,2 +1,0 @@
-UsernameField = input[name="email"]
-PasswordField = input[name="password"]

--- a/data/webkit-options/api.weibo.com.conf
+++ b/data/webkit-options/api.weibo.com.conf
@@ -1,2 +1,0 @@
-UsernameField = input[name="userId"]
-PasswordField = input[name="passwd"]

--- a/data/webkit-options/foursquare.com.conf
+++ b/data/webkit-options/foursquare.com.conf
@@ -1,2 +1,0 @@
-UsernameField = input[id="username"]
-PasswordField = input[id="password"]

--- a/data/webkit-options/identi.ca.conf
+++ b/data/webkit-options/identi.ca.conf
@@ -1,5 +1,0 @@
-UsernameField = input[name="nickname"]
-PasswordField = input[name="password"]
-# Force mobile version, so that layout does not scroll horizonally
-# https://bugs.launchpad.net/1051596
-UserAgent = Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3

--- a/data/webkit-options/login.live.com.conf
+++ b/data/webkit-options/login.live.com.conf
@@ -1,4 +1,0 @@
-ViewportWidth = 420
-ViewportHeight = 320
-UsernameField = input[name="login"]
-

--- a/data/webkit-options/www.linkedin.com.conf
+++ b/data/webkit-options/www.linkedin.com.conf
@@ -1,5 +1,0 @@
-UsernameField = input[name="session_key"]
-VerticalScrollBar = alwaysOn
-# Force mobile version, so that layout does not scroll horizonally
-# https://bugs.launchpad.net/1051596
-UserAgent = Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3

--- a/debian/account-plugin-flickr.maintscript
+++ b/debian/account-plugin-flickr.maintscript
@@ -1,1 +1,0 @@
-rm_conffile /etc/signon-ui/webkit-options.d/secure.flickr.com.conf 0.11+14.04.20140408

--- a/debian/account-plugin-foursquare.install
+++ b/debian/account-plugin-foursquare.install
@@ -1,3 +1,2 @@
-etc/signon-ui/webkit-options.d/foursquare.com.conf
 usr/share/accounts/services/foursquare-microblog.service
 usr/share/accounts/providers/foursquare.provider

--- a/debian/account-plugin-identica.install
+++ b/debian/account-plugin-identica.install
@@ -1,3 +1,2 @@
-etc/signon-ui/webkit-options.d/identi.ca.conf
 usr/share/accounts/services/identica-microblog.service
 usr/share/accounts/providers/identica.provider

--- a/debian/account-plugin-instagram.install
+++ b/debian/account-plugin-instagram.install
@@ -1,3 +1,2 @@
-etc/signon-ui/webkit-options.d/api.instagram.com.conf
 usr/share/accounts/services/instagram-microblog.service
 usr/share/accounts/providers/instagram.provider

--- a/debian/account-plugin-linkedin.install
+++ b/debian/account-plugin-linkedin.install
@@ -1,3 +1,2 @@
-etc/signon-ui/webkit-options.d/www.linkedin.com.conf
 usr/share/accounts/services/linkedin-microblog.service
 usr/share/accounts/providers/linkedin.provider

--- a/debian/account-plugin-sina.install
+++ b/debian/account-plugin-sina.install
@@ -1,3 +1,2 @@
-etc/signon-ui/webkit-options.d/api.weibo.com.conf
 usr/share/accounts/services/sina-microblog.service
 usr/share/accounts/providers/sina.provider

--- a/debian/account-plugin-sohu.install
+++ b/debian/account-plugin-sohu.install
@@ -1,3 +1,2 @@
-etc/signon-ui/webkit-options.d/api.t.sohu.com.conf
 usr/share/accounts/services/sohu-microblog.service
 usr/share/accounts/providers/sohu.provider

--- a/debian/control
+++ b/debian/control
@@ -4,16 +4,9 @@ Priority: optional
 Maintainer: Ubuntu Desktop Team <ubuntu-desktop@lists.ubuntu.com>
 Build-Depends: debhelper (>= 9),
                autotools-dev,
-               gobject-introspection,
-               python3,
                pkg-config,
-               libaccount-plugin-1.0-dev (>= 0.1.9),
                libaccounts-glib-dev (>= 1.10),
-               libjson-glib-dev,
-               libsignon-glib-dev,
-               libsoup2.4-dev,
-               valac (>= 0.16),
-               gnome-common,
+               libonline-accounts-plugin-dev,
                dh-autoreconf,
                libxml2-utils,
 Standards-Version: 3.9.4
@@ -21,20 +14,6 @@ Homepage: https://launchpad.net/account-plugins
 # If you aren't a member of ~online-accounts but need to upload packaging changes,
 # just go ahead.  ~online-accounts will notice and sync up the code again.
 Vcs-Bzr: https://code.launchpad.net/~online-accounts/account-plugins/trunk
-
-Package: libaccount-plugin-generic-oauth
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends},
-         signon-plugin-oauth2,
-Description: Online account plugin support lib for Unity 7 - generic OAuth
- Support library for the Unity 7 OAuth-based online account plugins
-
-Package: libaccount-plugin-google
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends},
-         signon-plugin-oauth2,
-Description: Online account plugin support lib for Unity 7 - Google
- Support library for the Unity 7 online account plugin
 
 Package: account-plugin-google
 Architecture: all
@@ -45,13 +24,6 @@ Description: Online account plugin for Unity - Google
  This plugin adds support for creating Google accounts in the Unity Control
  Center
 
-Package: libaccount-plugin-facebook
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends},
-         signon-plugin-oauth2,
-Description: Online account plugin support lib for Unity 7 - Facebook
- Support library for the Unity 7 online account plugin
-
 Package: account-plugin-facebook
 Architecture: all
 Depends: ${misc:Depends},
@@ -61,13 +33,6 @@ Description: Online account plugin for Unity - Facebook
  This plugin adds support for creating Facebook accounts in the Unity Control
  Center
 
-Package: libaccount-plugin-twitter
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends},
-         signon-plugin-oauth2,
-Description: Online account plugin support lib for Unity 7 - Twitter
- Support library for the Unity 7 online account plugin
-
 Package: account-plugin-twitter
 Architecture: all
 Depends: ${misc:Depends},
@@ -76,13 +41,6 @@ Depends: ${misc:Depends},
 Description: Online account plugin for Unity - Twitter
  This plugin adds support for creating Twitter accounts in the Unity Control
  Center
-
-Package: libaccount-plugin-flickr
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends},
-         signon-plugin-oauth2,
-Description: Online account plugin support lib for Unity 7 - Flickr
- Support library for the Unity 7 online account plugin
 
 Package: account-plugin-flickr
 Architecture: all

--- a/debian/libaccount-plugin-facebook.install
+++ b/debian/libaccount-plugin-facebook.install
@@ -1,1 +1,0 @@
-usr/lib/libaccount-plugin-1.0/providers/libfacebook.so

--- a/debian/libaccount-plugin-flickr.install
+++ b/debian/libaccount-plugin-flickr.install
@@ -1,1 +1,0 @@
-usr/lib/libaccount-plugin-1.0/providers/libflickr.so

--- a/debian/libaccount-plugin-generic-oauth.install
+++ b/debian/libaccount-plugin-generic-oauth.install
@@ -1,1 +1,0 @@
-usr/lib/libaccount-plugin-1.0/providers/libgeneric-oauth.so

--- a/debian/libaccount-plugin-google.install
+++ b/debian/libaccount-plugin-google.install
@@ -1,1 +1,0 @@
-usr/lib/libaccount-plugin-1.0/providers/libgoogle.so

--- a/debian/libaccount-plugin-twitter.install
+++ b/debian/libaccount-plugin-twitter.install
@@ -1,1 +1,0 @@
-usr/lib/libaccount-plugin-1.0/providers/libtwitter.so

--- a/debian/rules
+++ b/debian/rules
@@ -28,8 +28,6 @@ override_dh_auto_configure:
 
 override_dh_install:
 	rm -f debian/*/usr/lib/*/*/*.la
-	# the service is not valid anymore so we don't ship those
-	rm debian/tmp/etc/signon-ui/webkit-options.d/login.live.com.conf
 	mkdir -p debian/tmp/usr/share/account-plugins/tools
 	dh_install --fail-missing
 


### PR DESCRIPTION
Remove the obsolete Gtk plugins which were used in Unity7 and the WebKit option files, which have long been useless.